### PR TITLE
fix: fixed client generation action

### DIFF
--- a/.github/workflows/generate_clients.yaml
+++ b/.github/workflows/generate_clients.yaml
@@ -47,12 +47,11 @@ jobs:
 
       - name: generate openapi.json for reuse (for Go)
         env:
+          BUNDLE_DIRECTORY: "/home/runner/work/cloud-api-clients/cloud-api-clients/bundles"
           GENERATING_GO_CLIENT: true
         run: |
           source ./scripts/setenvs.sh
           python -m scripts.openapi.generate openapi_go.json
-        env:
-          BUNDLE_DIRECTORY: "/home/runner/work/cloud-api-clients/cloud-api-clients/bundles"
 
 
       # 2 - Generate the separate clients!


### PR DESCRIPTION
duplicate `env` stanza preventing action: https://github.com/aptible/cloud-api-clients/actions/runs/3183055649