### PR TITLE
fix: monkeypatching return object without rerelase of upstream service

### DIFF
--- a/clients/python/aptible_client/model/asset_output.py
+++ b/clients/python/aptible_client/model/asset_output.py
@@ -105,7 +105,6 @@ class AssetOutput(ModelNormal):
             'connections': ([ConnectionOutput],),  # noqa: E501
             'connects_to': ([str],),  # noqa: E501
             'outputs': ({str: (AssetTerraformOutput,)},),  # noqa: E501
-            'operation_id': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -124,7 +123,6 @@ class AssetOutput(ModelNormal):
         'connections': 'connections',  # noqa: E501
         'connects_to': 'connects_to',  # noqa: E501
         'outputs': 'outputs',  # noqa: E501
-        'operation_id': 'operation_id',  # noqa: E501
     }
 
     read_only_vars = {


### PR DESCRIPTION
On creates/repeats:

![image](https://user-images.githubusercontent.com/2961973/195416324-ea7b62dc-a089-4820-a7dd-118af0a27d97.png)

This works on destroys/redestroys:

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/2961973/195416925-4ed929fb-4424-4756-b3df-8916565b2fb1.png">